### PR TITLE
Allow directly passing in an element to initPlayer

### DIFF
--- a/src/embed-player.js
+++ b/src/embed-player.js
@@ -12,7 +12,8 @@ export default class EmbedPlayer {
 
     initPlayer(selector) {
         this.destroy();
-        const videoContainer = document.querySelector(selector);
+        const videoContainer = selector instanceof Element ?
+            selector : document.querySelector(selector);
         const videoElement = document.createElement('video');
         videoElement.setAttribute(
             'class',


### PR DESCRIPTION
This saves the user from ensuring the selector is unique,
e.g. in the case of multiple videos on one page.